### PR TITLE
Fixed tests with lxml 4.7.1 or higher.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+0.6.1 (unreleased)
+------------------
+
+* Fixed tests with lxml 4.7.1 or higher.
+  Fixes `issue 8 <https://github.com/repoze/repoze.xmliter/issues/8>`_.
+  [maurits]
+
 0.6 - 2014-09-21
 ----------------
 
@@ -41,7 +48,7 @@ Changelog
   the browser.
   [Laurence]
 
-0.1 - 2010-04-21 
+0.1 - 2010-04-21
 ----------------
 
 * Initial release

--- a/repoze/xmliter/tests.py
+++ b/repoze/xmliter/tests.py
@@ -11,12 +11,12 @@ import lxml.etree
 import sys
 if sys.version_info > (3,):
     unicode = str
-    
+
 class TestIterator(unittest.TestCase):
-    
+
     def create_tree(self):
         return lxml.html.fromstring(''.join(self.create_iterable()))
-    
+
     def create_iterable(self, preamble="", body=""):
         return [preamble,
             "<html>",
@@ -29,10 +29,10 @@ class TestIterator(unittest.TestCase):
                 "</body>"
             "</html>",
         ]
-    
+
     def test_html_serialization(self):
         """Test HTML serialization."""
-        
+
         @decorator.lazy(serializer=lxml.html.tostring)
         def app(a, b, c=u""):
             tree = self.create_tree()
@@ -49,10 +49,10 @@ class TestIterator(unittest.TestCase):
         self.assertEqual(
             lxml.html.tostring(result.tree, encoding='unicode'),
             u"".join(result.serialize(encoding=unicode)))
-        
+
     def test_xml_serialization(self):
         """Test XML serialization."""
-        
+
         @decorator.lazy
         def app(a, b, c=u""):
             tree = self.create_tree()
@@ -87,14 +87,14 @@ class TestIterator(unittest.TestCase):
         self.assertEqual(
             lxml.etree.tostring(result.tree, encoding='unicode'),
             u"".join(result.serialize(encoding=unicode)))
-    
+
     def test_getXMLSerializer(self):
         t = utils.getXMLSerializer(self.create_iterable())
-        self.failUnless(isinstance(t, serializer.XMLSerializer))
-        
+        self.assertTrue(isinstance(t, serializer.XMLSerializer))
+
         t2 = utils.getXMLSerializer(t)
-        self.failUnless(t2 is t)
-        
+        self.assertTrue(t2 is t)
+
         self.assertEqual(
             b"<html><head><title>My homepage</title></head><body>Hello, w&#246;rld!</body></html>",
             b"".join(t2))
@@ -105,38 +105,38 @@ class TestIterator(unittest.TestCase):
 
     def test_length(self):
         t = utils.getXMLSerializer(self.create_iterable())
-        self.failUnless(len(t) == 1)
-        self.failUnless(len(list(t)) == 1)
+        self.assertTrue(len(t) == 1)
+        self.assertTrue(len(list(t)) == 1)
 
     def test_getHTMLSerializer(self):
         t = utils.getHTMLSerializer(self.create_iterable(body='<img src="foo.png" />'), pretty_print=True)
-        self.failUnless(isinstance(t, serializer.XMLSerializer))
-        
+        self.assertTrue(isinstance(t, serializer.XMLSerializer))
+
         t2 = utils.getXMLSerializer(t)
-        self.failUnless(t2 is t)
-        
-        self.assertEqual(
-            b'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">\n<html>\n<head><title>My homepage</title></head>\n<body>Hello, w&#246;rld!<img src="foo.png">\n</body>\n</html>\n',
-            b"".join(t2))
+        self.assertTrue(t2 is t)
 
         self.assertEqual(
-            u'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">\n<html>\n<head><title>My homepage</title></head>\n<body>Hello, wörld!<img src="foo.png">\n</body>\n</html>\n',
-            u"".join(t2.serialize(encoding=unicode)))
-    
+            b'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">\n<html>\n<head><title>My homepage</title></head>\n<body>Hello, w&#246;rld!<img src="foo.png">\n</body>\n</html>',
+            b"".join(t2).strip())
+
+        self.assertEqual(
+            u'<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">\n<html>\n<head><title>My homepage</title></head>\n<body>Hello, wörld!<img src="foo.png">\n</body>\n</html>',
+            u"".join(t2.serialize(encoding=unicode)).strip())
+
     def test_getHTMLSerializer_doctype_xhtml_serializes_to_xhtml(self):
         t = utils.getHTMLSerializer(self.create_iterable(preamble='<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n', body='<img src="foo.png" />'), pretty_print=True)
-        self.failUnless(isinstance(t, serializer.XMLSerializer))
-        
+        self.assertTrue(isinstance(t, serializer.XMLSerializer))
+
         t2 = utils.getXMLSerializer(t)
-        self.failUnless(t2 is t)
-        
-        self.assertEqual(
-            b'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=ASCII" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, w&#246;rld!<img src="foo.png" /></body>\n</html>\n',
-            b"".join(t2))
+        self.assertTrue(t2 is t)
 
         self.assertEqual(
-            u'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, wörld!<img src="foo.png" /></body>\n</html>\n',
-            u"".join(t2.serialize(encoding=unicode)))
+            b'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=ASCII" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, w&#246;rld!<img src="foo.png" /></body>\n</html>',
+            b"".join(t2).strip())
+
+        self.assertEqual(
+            u'<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, wörld!<img src="foo.png" /></body>\n</html>',
+            u"".join(t2.serialize(encoding=unicode)).strip())
 
     def test_xsl(self):
         t = utils.getHTMLSerializer(self.create_iterable(body='<br>'))
@@ -155,37 +155,37 @@ class TestIterator(unittest.TestCase):
             </xsl:stylesheet>
             '''))
         t.tree = transform(t.tree)
-        self.failUnless('<br />' in str(t))
+        self.assertTrue('<br />' in str(t))
 
     def test_replace_doctype(self):
         t = utils.getHTMLSerializer(self.create_iterable(preamble='<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n', body='<img src="foo.png" />'), pretty_print=True, doctype="<!DOCTYPE html>")
-        self.failUnless(isinstance(t, serializer.XMLSerializer))
+        self.assertTrue(isinstance(t, serializer.XMLSerializer))
 
         t2 = utils.getXMLSerializer(t)
-        self.failUnless(t2 is t)
-        
-        self.assertEqual(
-            b'<!DOCTYPE html>\n<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=ASCII" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, w&#246;rld!<img src="foo.png" /></body>\n</html>\n',
-            b"".join(t2))
+        self.assertTrue(t2 is t)
 
         self.assertEqual(
-            u'<!DOCTYPE html>\n<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, wörld!<img src="foo.png" /></body>\n</html>\n',
-            u"".join(t2.serialize(encoding=unicode)))
+            b'<!DOCTYPE html>\n<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=ASCII" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, w&#246;rld!<img src="foo.png" /></body>\n</html>',
+            b"".join(t2).strip())
+
+        self.assertEqual(
+            u'<!DOCTYPE html>\n<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, wörld!<img src="foo.png" /></body>\n</html>',
+            u"".join(t2.serialize(encoding=unicode)).strip())
 
     def test_replace_doctype_blank(self):
         t = utils.getHTMLSerializer(self.create_iterable(preamble='<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n', body='<img src="foo.png" />'), pretty_print=True, doctype="")
-        self.failUnless(isinstance(t, serializer.XMLSerializer))
+        self.assertTrue(isinstance(t, serializer.XMLSerializer))
 
         t2 = utils.getXMLSerializer(t)
-        self.failUnless(t2 is t)
-        
-        self.assertEqual(
-            b'<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=ASCII" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, w&#246;rld!<img src="foo.png" /></body>\n</html>\n',
-            b"".join(t2))
+        self.assertTrue(t2 is t)
 
         self.assertEqual(
-            u'<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, wörld!<img src="foo.png" /></body>\n</html>\n',
-            u"".join(t2.serialize(encoding=unicode)))
+            b'<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=ASCII" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, w&#246;rld!<img src="foo.png" /></body>\n</html>',
+            b"".join(t2).strip())
+
+        self.assertEqual(
+            u'<html xmlns="http://www.w3.org/1999/xhtml">\n  <head>\n    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />\n    <title>My homepage</title>\n  </head>\n  <body>Hello, wörld!<img src="foo.png" /></body>\n</html>',
+            u"".join(t2.serialize(encoding=unicode)).strip())
 
 def test_suite():
     return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 
-__version__ = '0.6'
+__version__ = '0.6.1.dev0'
 
 import os
 from setuptools import setup, find_packages


### PR DESCRIPTION
Fixes https://github.com/repoze/repoze.xmliter/issues/8
We get more newlines at the end in a few cases. I simply added `strip()`.