### PR TITLE
chore: add 'python_requires'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,10 +48,10 @@ setup(name='repoze.xmliter',
       include_package_data=True,
       namespace_packages=['repoze'],
       zip_safe=False,
+      python_requires='>=3.7',
       install_requires=[
            'setuptools',
            'lxml >= 2.1.1',
            ],
-      test_suite="repoze.xmliter.tests",
       )
 


### PR DESCRIPTION
Follow-on to PR #12, which removed classifiers and testing support for older versions.

Also, drop OG testing fossil.