### PR TITLE
Build a wheel, but no universal wheel.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 0


### PR DESCRIPTION
If zest.releaser is used, the existence of a bdist_wheel section is interpreted as a wish to create a wheel, next to a source dist. With zest.releaser 8 a wheel is always created, if the wheel package is available. But version 8 is in alpha stage.

In other news, I have created a 0.x branch, in case we ever need a maintenance release.